### PR TITLE
Changes to adapt mod files for MOD to CPP translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 This model of a dentate granule cell was taken from the following
 paper and modified by Ivan Raikov:
 
@@ -15,6 +13,10 @@ understand the contribution of M and SK channels to the medium
 afterhyperpolarization (mAHP) following one or seven spikes, as 
 well as the contribution of M channels to the slow 
 afterhyperpolarization (sAHP). 
+
+### Compatibility
+
+- This version of the model is compatible with NEURON versions newer than 8.1 (#5)
 
 ### Running this model with NEURON and CoreNEURON
 

--- a/mechanisms/Gfluct3.mod
+++ b/mechanisms/Gfluct3.mod
@@ -194,18 +194,6 @@ INITIAL {
        }
 }
 
-VERBATIM
-#include "nrnran123.h"
-
-#if !NRNBBCORE
-/* backward compatibility */
-double nrn_random_pick(void* r);
-void* nrn_random_arg(int argpos);
-int nrn_random_isran123(void* r, uint32_t* id1, uint32_t* id2, uint32_t* id3);
-int nrn_random123_getseq(void* r, uint32_t* seq, char* which);
-#endif
-ENDVERBATIM
-
 FUNCTION mynormrand(mean, std) {
 VERBATIM
 	if (_p_donotuse) {
@@ -215,7 +203,7 @@ VERBATIM
 		if (_ran_compat == 2) {
 			x = nrnran123_normal((nrnran123_State*)_p_donotuse);
 		}else{		
-			x = nrn_random_pick(_p_donotuse);
+			x = nrn_random_pick((Rand*)_p_donotuse);
 		}
 #else
 		#pragma acc routine(nrnran123_normal) seq
@@ -281,7 +269,7 @@ PROCEDURE noiseFromRandom() {
 VERBATIM
 #if !NRNBBCORE
  {
-	void** pv = (void**)(&_p_donotuse);
+	Rand** pv = (Rand**)(&_p_donotuse);
 	if (_ran_compat == 2) {
 		fprintf(stderr, "Gfluct3.noiseFromRandom123 was previously called\n");
 		assert(0);
@@ -290,7 +278,7 @@ VERBATIM
 	if (ifarg(1)) {
 		*pv = nrn_random_arg(1);
 	}else{
-		*pv = (void*)0;
+		*pv = (Rand*)0;
 	}
  }
 #endif
@@ -350,7 +338,7 @@ static void bbcore_write(double* x, int* d, int* xx, int *offset, _threadargspro
 #if !NRNBBCORE
 		if (_ran_compat == 1) { 
 			char which;
-			void** pv = (void**)(&_p_donotuse);
+			Rand** pv = (Rand**)(&_p_donotuse);
 			/* error if not using Random123 generator */
 			if (!nrn_random_isran123(*pv, di, di+1, di+2)) {
 				fprintf(stderr, "Gfluct3: Random123 generator is required\n");

--- a/mechanisms/vecevent.mod
+++ b/mechanisms/vecevent.mod
@@ -149,7 +149,7 @@ static void bbcore_read(double* xarray, int* iarray, int* xoffset, int* ioffset,
   ia = iarray + *ioffset;
   dsize = ia[0];
   if (!_p_ptr) {
-    _p_ptr = (double*)vector_new(dsize);
+    _p_ptr = (double*)vector_new1(dsize);
   }
   assert(dsize == vector_capacity((IvocVect*)_p_ptr));
   dv = vector_vec((IvocVect*)_p_ptr);

--- a/mechanisms/vecevent.mod
+++ b/mechanisms/vecevent.mod
@@ -67,7 +67,7 @@ NET_RECEIVE (w) {
 DESTRUCTOR {
 VERBATIM
 #if !NRNBBCORE
-	void* vv = (void*)(_p_ptr);  
+	IvocVect* vv = (IvocVect*)(_p_ptr);
         if (vv) {
 		hoc_obj_unref(*vector_pobj(vv));
 	}
@@ -77,10 +77,10 @@ ENDVERBATIM
 
 PROCEDURE element() {
 VERBATIM	
-  { void* vv; int i, size; double* px;
+  { IvocVect* vv; int i, size; double* px;
 	i = (int)index;
 	if (i >= 0) {
-		vv = (void*)(_p_ptr);
+		vv = (IvocVect*)(_p_ptr);
 		if (vv) {
 			size = vector_capacity(vv);
 			px = vector_vec(vv);
@@ -102,13 +102,13 @@ PROCEDURE play() {
 VERBATIM
 #if !NRNBBCORE
   {
-	void** pv;
-	void* ptmp = NULL;
+	IvocVect** pv;
+	IvocVect* ptmp = NULL;
 	if (ifarg(1)) {
 		ptmp = vector_arg(1);
 		hoc_obj_ref(*vector_pobj(ptmp));
 	}
-	pv = (void**)(&_p_ptr);
+	pv = (IvocVect**)(&_p_ptr);
 	if (*pv) {
 		hoc_obj_unref(*vector_pobj(*pv));
 	}
@@ -124,10 +124,10 @@ static void bbcore_write(double* xarray, int* iarray, int* xoffset, int* ioffset
   double *xa, *dv;
   dsize = 0;
   if (_p_ptr) {
-    dsize = vector_capacity(_p_ptr);
+    dsize = vector_capacity((IvocVect*)_p_ptr);
   }
   if (iarray) {
-    void* vec = _p_ptr;
+    IvocVect* vec = (IvocVect*)_p_ptr;
     ia = iarray + *ioffset;
     xa = xarray + *xoffset;
     ia[0] = dsize;
@@ -149,10 +149,10 @@ static void bbcore_read(double* xarray, int* iarray, int* xoffset, int* ioffset,
   ia = iarray + *ioffset;
   dsize = ia[0];
   if (!_p_ptr) {
-    _p_ptr = vector_new1(dsize);
+    _p_ptr = (double*)vector_new(dsize);
   }
-  assert(dsize == vector_capacity(_p_ptr));
-  dv = vector_vec(_p_ptr);
+  assert(dsize == vector_capacity((IvocVect*)_p_ptr));
+  dv = vector_vec((IvocVect*)_p_ptr);
   for (i = 0; i < dsize; ++i) {
     dv[i] = xa[i];
   }

--- a/mechanisms/vecevent.mod
+++ b/mechanisms/vecevent.mod
@@ -149,10 +149,9 @@ static void bbcore_read(double* xarray, int* iarray, int* xoffset, int* ioffset,
   ia = iarray + *ioffset;
   dsize = ia[0];
 
-
   IvocVect* pv = (IvocVect*)_p_ptr;
   if(!pv) {
-    pv = (IvocVect*)vector_new1 (dsize);
+    pv = vector_new1(dsize);
   }
   assert(dsize == vector_capacity(pv));
   _p_ptr = (double*)pv;

--- a/mechanisms/vecevent.mod
+++ b/mechanisms/vecevent.mod
@@ -148,11 +148,16 @@ static void bbcore_read(double* xarray, int* iarray, int* xoffset, int* ioffset,
   xa = xarray + *xoffset;
   ia = iarray + *ioffset;
   dsize = ia[0];
-  if (!_p_ptr) {
-    _p_ptr = (double*)vector_new1(dsize);
+
+
+  IvocVect* pv = (IvocVect*)_p_ptr;
+  if(!pv) {
+    pv = (IvocVect*)vector_new1 (dsize);
   }
-  assert(dsize == vector_capacity((IvocVect*)_p_ptr));
-  dv = vector_vec((IvocVect*)_p_ptr);
+  assert(dsize == vector_capacity(pv));
+  _p_ptr = (double*)pv;
+
+  dv = vector_vec(pv);
   for (i = 0; i < dsize; ++i) {
     dv[i] = xa[i];
   }


### PR DESCRIPTION
* Remove random123 APIs as they are now included via headers
* fix vec_* api usage: use IvocVect* instead of void*
* Avoid passing void*

See https://github.com/neuronsimulator/nrn/pull/1597